### PR TITLE
Import ABC from collections.abc for Python 3 compatibility.

### DIFF
--- a/typish/functions/_get_origin.py
+++ b/typish/functions/_get_origin.py
@@ -1,5 +1,6 @@
 import typing
-from collections import deque, defaultdict, Set
+from collections import deque, defaultdict
+from collections.abc import Set
 
 
 def get_origin(t: type) -> type:


### PR DESCRIPTION
Fixes #14 