### PR TITLE
fix case of class which also exists in typing being found in typing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/*
+*.swp
+*.swo
+._*
+*.pyc
+*.*~
+*~
+.DS_Store

--- a/typish/functions/_get_origin.py
+++ b/typish/functions/_get_origin.py
@@ -11,11 +11,13 @@ def get_origin(t: type) -> type:
     :return: the origin of ``t`` or ``t`` if it is not generic.
     """
     from typish.functions._get_simple_name import get_simple_name
+    from typish.functions._is_from_typing import is_from_typing
 
     simple_name = get_simple_name(t)
     result = _type_per_alias.get(simple_name, None)
     if not result:
-        result = getattr(typing, simple_name, t)
+        if is_from_typing(t):
+            result = getattr(typing, simple_name, t)
     return result
 
 

--- a/typish/functions/_get_origin.py
+++ b/typish/functions/_get_origin.py
@@ -1,4 +1,5 @@
 import typing
+import inspect
 from collections import deque, defaultdict
 from collections.abc import Set
 

--- a/typish/functions/_get_origin.py
+++ b/typish/functions/_get_origin.py
@@ -17,10 +17,10 @@ def get_origin(t: type) -> type:
     simple_name = get_simple_name(t)
     result = _type_per_alias.get(simple_name, None)
     if not result:
-        if inspect.isclass(t) and is_from_typing(t):
-            result = getattr(typing, simple_name, t)
-        else:
+        if inspect.isclass(t) and not is_from_typing(t):
             result = t
+        else:
+            result = getattr(typing, simple_name, t)
     return result
 
 

--- a/typish/functions/_get_origin.py
+++ b/typish/functions/_get_origin.py
@@ -17,7 +17,7 @@ def get_origin(t: type) -> type:
     simple_name = get_simple_name(t)
     result = _type_per_alias.get(simple_name, None)
     if not result:
-        if inspect.isClass(t) and is_from_typing(t):
+        if inspect.isclass(t) and is_from_typing(t):
             result = getattr(typing, simple_name, t)
         else:
             result = t

--- a/typish/functions/_get_origin.py
+++ b/typish/functions/_get_origin.py
@@ -18,6 +18,8 @@ def get_origin(t: type) -> type:
     if not result:
         if is_from_typing(t):
             result = getattr(typing, simple_name, t)
+        else:
+            result = t
     return result
 
 

--- a/typish/functions/_get_origin.py
+++ b/typish/functions/_get_origin.py
@@ -16,7 +16,7 @@ def get_origin(t: type) -> type:
     simple_name = get_simple_name(t)
     result = _type_per_alias.get(simple_name, None)
     if not result:
-        if is_from_typing(t):
+        if inspect.isClass(t) and is_from_typing(t):
             result = getattr(typing, simple_name, t)
         else:
             result = t


### PR DESCRIPTION
I'm guessing at the right fix here... but it seems like checking if a fully qualified class is from typing is worthwhile.